### PR TITLE
init: Cleanup sysfs permissions

### DIFF
--- a/rootdir/etc/init.qcom-common.rc
+++ b/rootdir/etc/init.qcom-common.rc
@@ -261,33 +261,21 @@ on post-fs-data
     chown system radio /proc/touchpanel/flashlight_enable
     chmod 0660 /proc/touchpanel/flashlight_enable
 
-    chown system system /sys/devices/virtual/graphics/fb0/cabc
-    chmod 0660 /sys/devices/virtual/graphics/fb0/cabc
-
-    #chown system system /sys/devices/virtual/graphics/fb0/sre
-    #chmod 0660 /sys/devices/virtual/graphics/fb0/sre
-
-    #chown system system /sys/devices/virtual/graphics/fb0/color_enhance
-    #chmod 0660 /sys/devices/virtual/graphics/fb0/color_enhance
-
-    chown system system /sys/devices/virtual/graphics/fb0/rgb
-    chmod 0660 /sys/devices/virtual/graphics/fb0/rgb
-
-    #chown system system /sys/devices/virtual/graphics/fb0/aco
-    #chmod 0660 /sys/devices/virtual/graphics/fb0/aco
-
-    #chown system system /sys/devices/virtual/graphics/fb0/dyn_pu
-    #chmod 0660 /sys/devices/virtual/graphics/fb0/dyn_pu
+    # Graphics node permissions
+    chown system graphics /sys/class/graphics/fb0/dyn_pu
+    chmod 0664 /sys/class/graphics/fb0/dyn_pu
+    chown system graphics /sys/class/graphics/fb0/dynamic_fps
+    chmod 0664 /sys/class/graphics/fb0/dynamic_fps
+    chown system graphics /sys/class/graphics/fb0/idle_time
+    chmod 0664 /sys/class/graphics/fb0/idle_time
+    chown system graphics /sys/class/graphics/fb0/mode
+    chmod 0664 /sys/class/graphics/fb0/mode
+    chown system graphics /sys/class/graphics/fb0/modes
+    chmod 0664 /sys/class/graphics/fb0/modes
 
     # Vibrator intensity control
-    chown system system /sys/class/timed_output/vibrator/vtg_default
     chown system system /sys/class/timed_output/vibrator/vtg_level
-    chown system system /sys/class/timed_output/vibrator/vtg_max
-    chown system system /sys/class/timed_output/vibrator/vtg_min
-    chmod 0644 /sys/class/timed_output/vibrator/vtg_default
     chmod 0644 /sys/class/timed_output/vibrator/vtg_level
-    chmod 0644 /sys/class/timed_output/vibrator/vtg_max
-    chmod 0644 /sys/class/timed_output/vibrator/vtg_min
 
 on property:init.svc.wpa_supplicant=stopped
     stop dhcpcd


### PR DESCRIPTION
* LiveDisplay perms are set in vendor/cm
* Add missing fb0 perms after libinit_msm removal
* Remove unused vibrator perms

Change-Id: I3e287226b44c3b60ff210c4803775ac6f63b1519